### PR TITLE
Added a check so doors dont replace to block above with door when placed

### DIFF
--- a/plugins/Door.cs
+++ b/plugins/Door.cs
@@ -10,6 +10,9 @@ using MCGalaxy.Tasks;
 using MCGalaxy.Maths;
 using MCGalaxy.Blocks;
 using MCGalaxy.Network;
+
+//pluginref simplesurvival.dll
+
 namespace MCGalaxy {
 	public class DoorBlock {
 		public BlockID Item_Block        {get; set;}
@@ -482,6 +485,10 @@ namespace MCGalaxy {
 		
 		void PlaceDoor(Player p, ushort x, ushort y, ushort z, BlockID block)
 		{
+			if(!p.level.IsAirAt((ushort)x, (ushort)(y + 1), (ushort)z)) {
+				MCGalaxy.SimpleSurvival.InventoryAddBlocks(p, block, 1);
+				return;
+			}
 			if (!IsDoorItem(block))
 			{
 				return;

--- a/plugins/Door.cs
+++ b/plugins/Door.cs
@@ -485,12 +485,12 @@ namespace MCGalaxy {
 		
 		void PlaceDoor(Player p, ushort x, ushort y, ushort z, BlockID block)
 		{
-			if(!p.level.IsAirAt((ushort)x, (ushort)(y + 1), (ushort)z)) {
-				MCGalaxy.SimpleSurvival.InventoryAddBlocks(p, block, 1);
-				return;
-			}
 			if (!IsDoorItem(block))
 			{
+				return;
+			}
+			if(!p.level.IsAirAt((ushort)x, (ushort)(y + 1), (ushort)z)) {
+				MCGalaxy.SimpleSurvival.InventoryAddBlocks(p, block, 1);
 				return;
 			}
 			if ( y > 0 && p.level.FastGetBlock((ushort)x, (ushort)(y-1), (ushort)z) == 0) // if placing above air


### PR DESCRIPTION
This patch added a simple check by checking if the block above the door block thing is air, if so continue, else just return the used door and return. This is so the door doesn't replace blocks above it with door.